### PR TITLE
Change file mode and indent subelement test file

### DIFF
--- a/example/subelements/t8_test_subelement_functions.cxx
+++ b/example/subelements/t8_test_subelement_functions.cxx
@@ -18,94 +18,91 @@
   You should have received a copy of the GNU General Public License
   along with t8code; if not, write to the Free Software Foundation, Inc.,
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-*/  
-  
+*/
+
 #include <t8_schemes/t8_new_feature/t8_subelements_cxx.hxx>
 #include <example/common/t8_example_common.h>
-  
+
 /* In this example, a single quad element is refined into a transition cell of a specific type. 
  * At the moment, subelements are only implemented for the quad scheme. 
- * Valid types range from 1 to 15. */ 
-static void       
-t8_refine_quad_to_subelements () 
+ * Valid types range from 1 to 15. */
+static void
+t8_refine_quad_to_subelements ()
 {
-  t8_productionf ("Into the t8_refine_quad_to_subelements function.\n");
-  t8_productionf
+  t8_productionf ("Into the t8_refine_quad_to_subelements function.\n");
+  t8_productionf
     ("In this function we will construct a single element and refine it using subelements.\n");
-   t8_scheme_cxx_t * ts = t8_scheme_new_subelement_cxx ();
-  t8_eclass_scheme_c * class_scheme;
-  t8_element_t * element;
-  int                eclass, subelement_id, vertex_id, coords[P4EST_DIM],
+  t8_scheme_cxx_t    *ts = t8_scheme_new_subelement_cxx ();
+  t8_eclass_scheme_c *class_scheme;
+  t8_element_t       *element;
+  int                 eclass, subelement_id, vertex_id, coords[P4EST_DIM],
     num_subelements, num_vertices;
-   
-    /* Chose a type between 1 and 15 */ 
+
+  /* Chose a type between 1 and 15 */
   int                 type = 15;
-   
-    /* At the moment, subelements are only implemented for the wuad scheme. */ 
-    eclass = T8_ECLASS_QUAD;
-  class_scheme = ts->eclass_schemes[eclass];
-   
-    /* Allocate memory for a quad element and initialize it */ 
-    class_scheme->t8_element_new (1, &element);
-  class_scheme->t8_element_set_linear_id (element, 0, 0);
-  class_scheme->t8_element_is_valid (element);
-   
-    /* Allocate enough memory for subelements of the given type and initialize them */ 
-    num_subelements =
-    class_scheme->t8_element_get_number_of_subelements (type, element);
-  t8_element_t ** element_subelements =
+
+  /* At the moment, subelements are only implemented for the wuad scheme. */
+  eclass = T8_ECLASS_QUAD;
+  class_scheme = ts->eclass_schemes[eclass];
+
+  /* Allocate memory for a quad element and initialize it */
+  class_scheme->t8_element_new (1, &element);
+  class_scheme->t8_element_set_linear_id (element, 0, 0);
+  class_scheme->t8_element_is_valid (element);
+
+  /* Allocate enough memory for subelements of the given type and initialize them */
+  num_subelements =
+    class_scheme->t8_element_get_number_of_subelements (type, element);
+  t8_element_t      **element_subelements =
     T8_ALLOC (t8_element_t *, num_subelements);
-  class_scheme->t8_element_new (num_subelements, element_subelements);
-   
-    /* Create all subelements for the given type from the initial quad element. */ 
-    class_scheme->t8_element_to_subelement (element, type,
-                                            element_subelements);
-   t8_productionf ("The given type is type %i.\n", type);
-  t8_productionf
+  class_scheme->t8_element_new (num_subelements, element_subelements);
+
+  /* Create all subelements for the given type from the initial quad element. */
+  class_scheme->t8_element_to_subelement (element, type, element_subelements);
+  t8_productionf ("The given type is type %i.\n", type);
+  t8_productionf
     ("The transition cell of type %i consists of %i subelements with ids ranging from 0 to %i.\n",
      type, num_subelements, num_subelements - 1);
-  t8_productionf ("The coordinates of these subelements are:\n");
-   
-    /* Iterate through all subelements and determine their vertex coordinates */ 
-    for (subelement_id = 0; subelement_id < num_subelements; ++subelement_id) {
-    
-      /* determine the shape of the subelement and use it to determine the number of vertices it has (triangle -> 3 vertices) */ 
+  t8_productionf ("The coordinates of these subelements are:\n");
+
+  /* Iterate through all subelements and determine their vertex coordinates */
+  for (subelement_id = 0; subelement_id < num_subelements; ++subelement_id) {
+
+    /* determine the shape of the subelement and use it to determine the number of vertices it has (triangle -> 3 vertices) */
     const t8_element_shape_t shape =
       class_scheme->t8_element_shape (element_subelements[subelement_id]);
-    num_vertices = t8_eclass_num_vertices[shape];
-     
-      /* Iterate over all vertices of the subelement and, determine their coordinates and print them */ 
-      for (vertex_id = 0; vertex_id < num_vertices; ++vertex_id) {
-      class_scheme->t8_element_vertex_coords (element_subelements
-                                               [subelement_id], vertex_id,
-                                               coords);
-       t8_productionf ("Sub_id = %i; Vertex = %i; Coordinates = (%i,%i)\n",
-                         subelement_id, vertex_id, coords[0], coords[1]);
-    }
-  }
-   
-    /* TODO: Print the transition cell in Paraview. */ 
-    
-    /* free memory */ 
-    class_scheme->t8_element_destroy (1, &element);
-  class_scheme->t8_element_destroy (num_subelements, element_subelements);
-  T8_FREE (element_subelements);
-  t8_scheme_cxx_unref (&ts);
-}
+    num_vertices = t8_eclass_num_vertices[shape];
 
- int             
-main (int argc, char **argv) 
+    /* Iterate over all vertices of the subelement and, determine their coordinates and print them */
+    for (vertex_id = 0; vertex_id < num_vertices; ++vertex_id) {
+      class_scheme->t8_element_vertex_coords (element_subelements
+                                              [subelement_id], vertex_id,
+                                              coords);
+      t8_productionf ("Sub_id = %i; Vertex = %i; Coordinates = (%i,%i)\n",
+                      subelement_id, vertex_id, coords[0], coords[1]);
+    }
+  }
+
+  /* TODO: Print the transition cell in Paraview. */
+
+  /* free memory */
+  class_scheme->t8_element_destroy (1, &element);
+  class_scheme->t8_element_destroy (num_subelements, element_subelements);
+  T8_FREE (element_subelements);
+  t8_scheme_cxx_unref (&ts);
+}
+
+int
+main (int argc, char **argv)
 {
-  int                mpiret;
-   mpiret = sc_MPI_Init (&argc, &argv);
-  SC_CHECK_MPI (mpiret);
-   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
-  t8_init (SC_LP_DEFAULT);
-   t8_refine_quad_to_subelements ();
-   sc_finalize ();
-  mpiret = sc_MPI_Finalize ();
-   SC_CHECK_MPI (mpiret);
-   return 0;
-}
-
- 
+  int                 mpiret;
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+  sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
+  t8_init (SC_LP_DEFAULT);
+  t8_refine_quad_to_subelements ();
+  sc_finalize ();
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+  return 0;
+}


### PR DESCRIPTION
File mode was set to executable and windows carriage returns were all over the place.

Reset file mode and remove carriage returns.